### PR TITLE
Fix: Corrige TypeError em handle_custom_answer por argumento faltante

### DIFF
--- a/main.py
+++ b/main.py
@@ -1490,7 +1490,7 @@ def build_tela_custom_quiz(page: Page):
         animate_opacity=ANIMACAO_APARICAO_TEXTO_BOTAO
     )
 
-    def handle_custom_answer(e, botao_clicado_ref, todos_botoes_opcoes_ref, txt_feedback_ctrl_ref, txt_lembrete_ctrl_ref, btn_proxima_ctrl_ref, question_data_ref):
+    def handle_custom_answer(e, botao_clicado_ref, todos_botoes_opcoes_ref, txt_feedback_ctrl_ref, txt_lembrete_ctrl_ref, btn_proxima_ctrl_ref, question_data_ref, formula_config_ref):
         selected_option = botao_clicado_ref.data['option']
         correct_answer = question_data_ref['correct_answer']
         reminder_text = question_data_ref.get('reminder_template', "")


### PR DESCRIPTION
A função handle_custom_answer estava sendo chamada com 8 argumentos, mas sua definição esperava apenas 7. Isso causava um TypeError no modo de quiz personalizado.

A correção adiciona o parâmetro 'formula_config_ref' que faltava à definição da função, pois ele já era utilizado dentro do corpo da função.