### PR TITLE
feat: Implement missing quiz modes

### DIFF
--- a/script.js
+++ b/script.js
@@ -258,7 +258,266 @@ const screenLogics = {
             byTableEl.innerHTML = tableHTML;
         }
     },
-    // Adicionar lógicas para as outras telas...
+    quiz_invertido: async () => {
+        const questionEl = document.getElementById('question-inv');
+        const optionsEl = document.getElementById('options-inv');
+        const feedbackEl = document.getElementById('feedback-inv');
+        const nextButton = document.getElementById('next-question-inv');
+
+        async function loadQuestion() {
+            feedbackEl.textContent = '';
+            nextButton.style.display = 'none';
+            optionsEl.innerHTML = '<div class="spinner-border" role="status"><span class="visually-hidden">Loading...</span></div>';
+
+            const questionData = await apiCall('selecionar_proxima_pergunta_invertida');
+            state.currentQuestion = questionData;
+            if (!questionData) {
+                questionEl.textContent = 'Parabéns, você completou todas as questões!';
+                optionsEl.innerHTML = '';
+                return;
+            }
+
+            questionEl.textContent = `? x ? = ${questionData.resultado}`;
+            const options = await apiCall('gerar_opcoes_invertidas', questionData.resultado);
+            const correctAnswer = `${questionData.fator1} x ${questionData.fator2}`;
+
+            optionsEl.innerHTML = options.map(opt => `
+                <div class="col-6 mb-2">
+                    <button class="btn btn-primary w-100 option-btn">${opt.fator1} x ${opt.fator2}</button>
+                </div>
+            `).join('');
+
+            const startTime = Date.now();
+            optionsEl.querySelectorAll('.option-btn').forEach(button => {
+                button.addEventListener('click', () => {
+                    const responseTime = (Date.now() - startTime) / 1000;
+                    const isCorrect = button.textContent.trim() === correctAnswer;
+                    apiCall('registrar_resposta', state.currentQuestion, isCorrect, responseTime);
+
+                    feedbackEl.textContent = isCorrect ? 'Correto!' : `Errado! A resposta era ${correctAnswer}`;
+                    feedbackEl.className = isCorrect ? 'text-success' : 'text-danger';
+                    nextButton.style.display = 'block';
+                    optionsEl.querySelectorAll('.option-btn').forEach(btn => btn.disabled = true);
+                });
+            });
+        }
+
+        nextButton.addEventListener('click', loadQuestion);
+        loadQuestion();
+    },
+    quiz_cronometrado: () => {
+        const scoreEl = document.getElementById('score');
+        const timerEl = document.getElementById('timer');
+        const questionEl = document.getElementById('question-timed');
+        const answerInput = document.getElementById('answer-timed');
+        const feedbackEl = document.getElementById('feedback-timed');
+        const startButton = document.getElementById('start-timed-quiz');
+        const backToMenuButton = document.getElementById('back-to-menu-timed');
+
+        function resetQuiz() {
+            state.timedQuiz.score = 0;
+            state.timedQuiz.timeLeft = 60;
+            state.timedQuiz.isActive = false;
+            if (state.timedQuiz.timer) clearInterval(state.timedQuiz.timer);
+
+            scoreEl.textContent = 'Pontuação: 0';
+            timerEl.textContent = 'Tempo: 60';
+            questionEl.textContent = 'Pressione Iniciar para começar';
+            answerInput.value = '';
+            answerInput.disabled = true;
+            feedbackEl.textContent = '';
+            startButton.style.display = 'block';
+            backToMenuButton.style.display = 'none';
+        }
+
+        async function nextQuestion() {
+            const questionData = await apiCall('selecionar_proxima_pergunta');
+            state.currentQuestion = questionData;
+            if (!questionData) {
+                endQuiz();
+                return;
+            }
+            questionEl.textContent = `${questionData.fator1} x ${questionData.fator2} = ?`;
+            answerInput.value = '';
+            answerInput.focus();
+        }
+
+        function endQuiz() {
+            state.timedQuiz.isActive = false;
+            clearInterval(state.timedQuiz.timer);
+            questionEl.textContent = `Tempo esgotado! Pontuação final: ${state.timedQuiz.score}`;
+            answerInput.disabled = true;
+            startButton.style.display = 'none';
+            backToMenuButton.style.display = 'block';
+            apiCall('registrar_pontuacao_cronometrada', state.timedQuiz.score);
+        }
+
+        function handleAnswer(e) {
+            if (e.key === 'Enter' && state.timedQuiz.isActive) {
+                const userAnswer = parseInt(answerInput.value);
+                const correctAnswer = state.currentQuestion.fator1 * state.currentQuestion.fator2;
+                const isCorrect = userAnswer === correctAnswer;
+
+                if (isCorrect) {
+                    state.timedQuiz.score++;
+                    scoreEl.textContent = `Pontuação: ${state.timedQuiz.score}`;
+                    feedbackEl.textContent = 'Correto!';
+                    feedbackEl.className = 'text-success';
+                } else {
+                    feedbackEl.textContent = `Errado! A resposta era ${correctAnswer}`;
+                    feedbackEl.className = 'text-danger';
+                }
+                apiCall('registrar_resposta', state.currentQuestion, isCorrect, null);
+                setTimeout(() => {
+                    feedbackEl.textContent = '';
+                    nextQuestion();
+                }, 1000);
+            }
+        }
+
+        startButton.addEventListener('click', () => {
+            resetQuiz();
+            state.timedQuiz.isActive = true;
+            answerInput.disabled = false;
+            startButton.style.display = 'none';
+            backToMenuButton.style.display = 'none';
+
+            state.timedQuiz.timer = setInterval(() => {
+                state.timedQuiz.timeLeft--;
+                timerEl.textContent = `Tempo: ${state.timedQuiz.timeLeft}`;
+                if (state.timedQuiz.timeLeft <= 0) {
+                    endQuiz();
+                }
+            }, 1000);
+
+            nextQuestion();
+        });
+
+        answerInput.addEventListener('keyup', handleAnswer);
+        resetQuiz();
+    },
+    memorizacao: () => {
+        const contentEl = document.getElementById('memorization-content');
+        let state = {
+            stage: 'selection', // selection, memorization, test
+            tableNumber: null,
+            questions: [],
+            currentQuestionIndex: 0,
+            correctAnswers: 0,
+        };
+
+        function renderSelection() {
+            let buttonsHTML = '<h2>Qual tabuada você quer memorizar?</h2><div class="d-grid gap-2 col-6 mx-auto">';
+            for (let i = 1; i <= 10; i++) {
+                buttonsHTML += `<button class="btn btn-primary select-table-btn" data-table="${i}">Tabuada do ${i}</button>`;
+            }
+            buttonsHTML += '</div>';
+            contentEl.innerHTML = buttonsHTML;
+
+            contentEl.querySelectorAll('.select-table-btn').forEach(button => {
+                button.addEventListener('click', (e) => {
+                    state.tableNumber = parseInt(e.target.dataset.table);
+                    state.stage = 'memorization';
+                    renderMemorization();
+                });
+            });
+        }
+
+        function renderMemorization() {
+            let tableHTML = `<h2>Memorize a Tabuada do ${state.tableNumber}</h2><table class="table">`;
+            for (let i = 1; i <= 10; i++) {
+                tableHTML += `<tr><td>${state.tableNumber} x ${i}</td><td>=</td><td>${state.tableNumber * i}</td></tr>`;
+            }
+            tableHTML += '</table><button class="btn btn-primary" id="start-test-btn">Iniciar Teste</button>';
+            contentEl.innerHTML = tableHTML;
+
+            document.getElementById('start-test-btn').addEventListener('click', () => {
+                state.stage = 'test';
+                generateTestQuestions();
+                renderTest();
+            });
+        }
+
+        function generateTestQuestions() {
+            state.questions = [];
+            for (let i = 1; i <= 10; i++) {
+                state.questions.push({ fator1: state.tableNumber, fator2: i, answer: state.tableNumber * i });
+            }
+            // Shuffle questions
+            state.questions.sort(() => Math.random() - 0.5);
+            state.currentQuestionIndex = 0;
+            state.correctAnswers = 0;
+        }
+
+        function renderTest() {
+            if (state.currentQuestionIndex >= state.questions.length) {
+                renderTestResults();
+                return;
+            }
+
+            const question = state.questions[state.currentQuestionIndex];
+            const questionText = `${question.fator1} x ${question.fator2} = ?`;
+            contentEl.innerHTML = `
+                <h2>Teste de Memorização</h2>
+                <h3>${questionText}</h3>
+                <input type="number" class="form-control w-50 mx-auto" id="memorization-answer">
+                <button class="btn btn-primary mt-3" id="submit-answer-btn">Responder</button>
+                <p id="feedback-memorization" class="mt-2"></p>
+                <div class="progress mt-3" style="height: 20px;">
+                    <div class="progress-bar" role="progressbar" style="width: ${state.currentQuestionIndex / state.questions.length * 100}%;" aria-valuenow="${state.currentQuestionIndex}" aria-valuemin="0" aria-valuemax="${state.questions.length}"></div>
+                </div>
+            `;
+
+            const answerInput = document.getElementById('memorization-answer');
+            const submitBtn = document.getElementById('submit-answer-btn');
+            const feedbackEl = document.getElementById('feedback-memorization');
+
+            const submitAnswer = () => {
+                const userAnswer = parseInt(answerInput.value);
+                const isCorrect = userAnswer === question.answer;
+
+                if (isCorrect) {
+                    state.correctAnswers++;
+                    feedbackEl.textContent = 'Correto!';
+                    feedbackEl.className = 'text-success';
+                } else {
+                    feedbackEl.textContent = `Errado. A resposta é ${question.answer}.`;
+                    feedbackEl.className = 'text-danger';
+                }
+
+                apiCall('registrar_resposta', {fator1: question.fator1, fator2: question.fator2}, isCorrect, null, 'memorizacao');
+
+                submitBtn.disabled = true;
+                answerInput.disabled = true;
+
+                setTimeout(() => {
+                    state.currentQuestionIndex++;
+                    renderTest();
+                }, 1500);
+            };
+
+            submitBtn.addEventListener('click', submitAnswer);
+            answerInput.addEventListener('keyup', (e) => {
+                if (e.key === 'Enter') {
+                    submitAnswer();
+                }
+            });
+            answerInput.focus();
+        }
+
+        function renderTestResults() {
+            const accuracy = (state.correctAnswers / state.questions.length) * 100;
+            contentEl.innerHTML = `
+                <h2>Resultado do Teste</h2>
+                <p>Você acertou ${state.correctAnswers} de ${state.questions.length} questões.</p>
+                <p>Sua precisão foi de ${accuracy.toFixed(0)}%.</p>
+                <button class="btn btn-primary" id="restart-memorization-btn">Tentar Novamente</button>
+            `;
+            document.getElementById('restart-memorization-btn').addEventListener('click', renderSelection);
+        }
+
+        renderSelection();
+    },
 };
 
 // Router


### PR DESCRIPTION
Adds the JavaScript logic for the 'quiz_invertido', 'memorizacao', and 'quiz_cronometrado' modes. These were previously showing blank screens because their logic was not implemented in the `screenLogics` object in `script.js`.